### PR TITLE
Add fast path for code without "idx" in the source [1/2]

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -12,6 +12,8 @@
 module.exports = context => {
   const t = context.types;
 
+  const idxRe = /\bidx\b/;
+
   class TransformedTernary {
     constructor(expression, generateUid) {
       this.generateUid = generateUid;
@@ -164,12 +166,15 @@ module.exports = context => {
 
   return {
     visitor: {
-      Program(path) {
-        // We're very strict about the shape of idx. Some transforms, like
-        // "babel-plugin-transform-async-to-generator", will convert arrow
-        // functions inside async functions into regular functions. So we do
-        // our transformation before any one else interferes.
-        path.traverse(idxVisitor);
+      Program(path, state) {
+        // If there can't reasonably be an idx call, exit fast.
+        if (path.scope.getOwnBinding('idx') || idxRe.test(state.file.code)) {
+          // We're very strict about the shape of idx. Some transforms, like
+          // "babel-plugin-transform-async-to-generator", will convert arrow
+          // functions inside async functions into regular functions. So we do
+          // our transformation before any one else interferes.
+          path.traverse(idxVisitor);
+        }
       },
     },
   };

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -335,4 +335,56 @@ describe('babel-plugin-idx', () => {
       ${asyncToGeneratorHelperCode}
     `);
   });
+
+  it('transforms idx calls when an idx import binding is in scope', () => {
+    expect(`
+      import idx from 'idx';
+      idx(base, _ => _.b);
+    `).toTransformInto(`
+      var _ref;
+      import idx from 'idx';
+      (_ref = base) != null ? _ref.b : _ref;
+    `);
+  });
+
+  it('transforms idx calls when an idx const binding is in scope', () => {
+    expect(`
+      const idx = require('idx');
+      idx(base, _ => _.b);
+    `).toTransformInto(`
+      var _ref;
+      const idx = require('idx');
+      (_ref = base) != null ? _ref.b : _ref;
+    `);
+  });
+
+  it('transforms deep idx calls when an idx import binding is in scope', () => {
+    expect(`
+      import idx from 'idx';
+      function f() {
+        idx(base, _ => _.b);
+      }
+    `).toTransformInto(`
+      import idx from 'idx';
+      function f() {
+        var _ref;
+        (_ref = base) != null ? _ref.b : _ref;
+      }
+    `);
+  });
+
+  it('transforms deep idx calls when an idx const binding is in scope', () => {
+    expect(`
+      const idx = require('idx');
+      function f() {
+        idx(base, _ => _.b);
+      }
+    `).toTransformInto(`
+      const idx = require('idx');
+      function f() {
+        var _ref;
+        (_ref = base) != null ? _ref.b : _ref;
+      }
+    `);
+  });
 });


### PR DESCRIPTION
First, check if there's an `idx` binding in scope. If you're using `idx`, you likely have a top-level `var idx = require('idx')` or `import idx from 'idx';`. We can check for this cheaply since the scope has already been calculated. If that fails, then do a quick regex check for `idx` in the source.