### PR TITLE
Setup CircleCI testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # idx
 
+[![Circle Status](https://circleci.com/gh/facebookincubator/idx/tree/master.svg?style=shield&circle-token=da61f3cf105f22309c8ca0ba4482daa538bf5349)](https://circleci.com/gh/facebookincubator/idx)
+
 `idx` is a utility function for traversing properties on objects and arrays.
 
 If an intermediate property is either null or undefined, it is instead returned.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  node:
+    version: 4
+
+dependencies:
+  cache_directories:
+    - ~/.cache/yarn
+  override:
+    - yarn
+
+test:
+  override:
+    - yarn test
+    - yarn lint

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "build": "lerna run build",
     "lint": "eslint --ignore-path .gitignore .",
+    "postinstall": "lerna bootstrap --concurrency=1",
     "test": "lerna run test"
   },
   "devDependencies": {

--- a/packages/babel-plugin-idx/package.json
+++ b/packages/babel-plugin-idx/package.json
@@ -23,6 +23,7 @@
     "jest": "^19.0.2"
   },
   "jest": {
+    "testEnvironment": "node",
     "rootDir": "src"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -22,6 +22,7 @@
     "jest": "^19.0.2"
   },
   "jest": {
+    "testEnvironment": "node",
     "rootDir": "src"
   }
 }


### PR DESCRIPTION
- [x] Missing `circle-token` in README.

Unfortunately, due to https://github.com/lerna/lerna/issues/671, I had to add `--concurrency=1` to `lerna bootstrap`.

Note: `"testEnvironment": "node"` makes the tests a bit faster since we avoid jsdom - which isn't necessary for these tests.