### PR TITLE
Fix idx transform when idx's parent is a scope creating expression

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -120,8 +120,8 @@ module.exports = context => {
             temp,
           },
         );
-        path.scope.push({id: temp});
         path.replaceWith(replacement);
+        path.scope.push({id: temp});
       }
     },
   };

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -422,6 +422,17 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
+  it('transforms when the idx parent is a scope creating expression', () => {
+    expect(`
+      (() => idx(base, _ => _.b));
+    `).toTransformInto(`
+      () => {
+        var _ref;
+        return (_ref = base) != null ? _ref.b : _ref;
+      };
+    `);
+  });
+
   describe('functional', () => {
     it('works with only properties', () => {
       expect(`


### PR DESCRIPTION
woops :blush

Without this fix:

```js
(() => idx(base, _ => _.b));

// transforms into:

() => {
      var _ref;
      return idx(base, _ => _.b);
};
```