### PR TITLE
Rework the idx babel transform to be more reliable

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -133,6 +133,16 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
+  it('does not transform an idx function not imported from `idx`', () => {
+    expect(`
+      function idx() {}
+      idx(base, _ => _.b.c.d.e);
+    `).toTransformInto(`
+      function idx() {}
+      idx(base, _ => _.b.c.d.e);
+    `);
+  });
+
   it('does not remove the require if it cannot transform an expression', () => {
     expect(`
       const idx = require('idx');


### PR DESCRIPTION
Now, instead of searching for calls to the `idx` function, it searches
for `require('idx')` or `import idx from 'idx'` calls, finds all
references to the assigned variable and transform them.

This also allows us to remove the require() call, which is no longer
needed (and in fact is causing issues when using `haste` in RN due to not
being able to find the `idx` module (since it no longer has the
`@providesModule` annotation).