### PR TITLE
Rework the idx babel transform to be more reliable

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -181,7 +181,9 @@ module.exports = context => {
 
   const declareVisitor = {
     'ImportDeclaration|VariableDeclarator'(path, state) {
-      if (!isIdxImportOrRequire(path.node, 'idx')) { // TODO: Make this configurable
+      const importName = state.opts.importName || 'idx';
+
+      if (!isIdxImportOrRequire(path.node, importName)) {
         return;
       }
 
@@ -195,7 +197,7 @@ module.exports = context => {
       idxBinding.constantViolations.forEach(refPath => {
         throw state.file.buildCodeFrameError(
           refPath.node,
-          '`idx` cannot be redefined.'
+          '`idx` cannot be redefined.',
         );
       });
 


### PR DESCRIPTION
With this PR, instead of searching for calls to the idx function, it searches
for require('idx') or import idx from 'idx' calls, finds all
references to the assigned variable and transform them.

This also allows us to remove the require() call, which is no longer
needed (and in fact is causing issues when using haste in RN due to not
being able to find the idx module (since it no longer has the
@providesModule annotation).

----

This is a follow-up PR based on the feedback received in https://github.com/facebookincubator/idx/pull/22, reusing the commit ed87aaa1eb430e1e735fd6200d43a895300e3cd7 from @zertosh and adding a small extra functionality (the ability to customize the require/import name).