### PR TITLE
Remove fast "idx" binding check

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -224,7 +224,7 @@ module.exports = context => {
     visitor: {
       Program(path, state) {
         // If there can't reasonably be an idx call, exit fast.
-        if (path.scope.getOwnBinding('idx') || idxRe.test(state.file.code)) {
+        if (idxRe.test(state.file.code)) {
           // We're very strict about the shape of idx. Some transforms, like
           // "babel-plugin-transform-async-to-generator", will convert arrow
           // functions inside async functions into regular functions. So we do


### PR DESCRIPTION
The idea behind `path.scope.getOwnBinding('idx')` was that since the scope is already pre-calculated, we could avoid the regex check in cases where `idx` was a top-level import. However, if you do `import type idx from 'idx'`, you get these warnings:

```
console.warn ../node_modules/babel-traverse/lib/scope/index.js:1015

          You or one of the Babel plugins you are using are using Flow declarations as bindings.
          Support for this will be removed in version 6.8. To find out the caller, grep for this
          message and change it to a `console.trace()`.
```

Since this is a micro-optimization, I don't think it's worth the confusing warning (especially during tests).