### PR TITLE
Fix fast-path incorrect exit on non-idx import names

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -192,9 +192,7 @@ module.exports = context => {
 
   const declareVisitor = {
     'ImportDeclaration|VariableDeclarator'(path, state) {
-      const importName = state.opts.importName || 'idx';
-
-      if (!isIdxImportOrRequire(path.node, importName)) {
+      if (!isIdxImportOrRequire(path.node, state.importName)) {
         return;
       }
 
@@ -234,13 +232,15 @@ module.exports = context => {
   return {
     visitor: {
       Program(path, state) {
+        const importName = state.opts.importName || 'idx';
         // If there can't reasonably be an idx call, exit fast.
-        if (idxRe.test(state.file.code)) {
+        if (importName !== 'idx' || idxRe.test(state.file.code)) {
           // We're very strict about the shape of idx. Some transforms, like
           // "babel-plugin-transform-async-to-generator", will convert arrow
           // functions inside async functions into regular functions. So we do
           // our transformation before any one else interferes.
-          path.traverse(declareVisitor, state);
+          const newState = {file: state.file, importName};
+          path.traverse(declareVisitor, newState);
         }
       },
     },

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -688,10 +688,10 @@ describe('babel-plugin-idx', () => {
   it('allows configuration of the import name', () => {
     expect({
       code: `
-        import idx from 'myIdx';
-        idx(base, _ => _.b);
+        import i_d_x from 'i_d_x';
+        i_d_x(base, _ => _.b);
       `,
-      options: {importName: 'myIdx'},
+      options: {importName: 'i_d_x'},
     }).toTransformInto(`
       var _ref;
       (_ref = base) != null ? _ref.b : _ref;
@@ -702,11 +702,11 @@ describe('babel-plugin-idx', () => {
     expect({
       code: `
         import idx from 'idx';
-        import myIdx from 'myIdx';
-        myIdx(base, _ => _.b);
+        import i_d_x from 'i_d_x';
+        i_d_x(base, _ => _.b);
         idx(base, _ => _.c);
       `,
-      options: {importName: 'myIdx'},
+      options: {importName: 'i_d_x'},
     }).toTransformInto(`
       var _ref;
       import idx from 'idx';
@@ -718,10 +718,10 @@ describe('babel-plugin-idx', () => {
   it('allows configuration of the require name', () => {
     expect({
       code: `
-        const idx = require('myIdx');
-        idx(base, _ => _.b);
+        const i_d_x = require('i_d_x');
+        i_d_x(base, _ => _.b);
       `,
-      options: {importName: 'myIdx'},
+      options: {importName: 'i_d_x'},
     }).toTransformInto(`
       var _ref;
       (_ref = base) != null ? _ref.b : _ref;
@@ -732,11 +732,11 @@ describe('babel-plugin-idx', () => {
     expect({
       code: `
         const idx = require('idx');
-        const myIdx = require('myIdx');
-        myIdx(base, _ => _.b);
+        const i_d_x = require('i_d_x');
+        i_d_x(base, _ => _.b);
         idx(base, _ => _.c);
       `,
-      options: {importName: 'myIdx'},
+      options: {importName: 'i_d_x'},
     }).toTransformInto(`
       var _ref;
       const idx = require('idx');


### PR DESCRIPTION
After #23, the `idx` import module name and the binding itself don't have to be `idx`. This PR only does the fast path test when `importName` is `idx`. It also fixes the `importName` test so that it doesn't accidentally trip the fast path test (the updated tests would fail without this change).