### PR TITLE
Throw on call expression in the callback parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ of maybe-typed properties.
 
 ## Usage
 
-Consider the following type:
+Consider the following type for `props`:
 
 ```javascript
-const props: {
+type User = {
   user: ?{
     name: string,
     friends: ?Array<User>,
@@ -36,6 +36,20 @@ idx(props, _ => _.user.friends[0].friends)
 
 The second argument must be a function that returns one or more nested member
 expressions. Any other expression has undefined behavior.
+
+## Flow Type
+
+[Flow](https://flow.org/) understands the `idx` idiom:
+
+```javascript
+// @flow
+
+import idx from 'idx';
+
+function getName(props: User): ?string {
+  return idx(props, _ => _.user.name);
+}
+```
 
 ## Babel Transform
 

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -124,17 +124,7 @@ module.exports = context => {
   }
 
   function makeChain(node, state, inside) {
-    if (t.isCallExpression(node)) {
-      return makeChain(
-        node.callee,
-        state,
-        makeCondition(
-          t.CallExpression(state.temp, node.arguments),
-          state,
-          inside,
-        ),
-      );
-    } else if (t.isMemberExpression(node)) {
+    if (t.isMemberExpression(node)) {
       return makeChain(
         node.object,
         state,
@@ -156,7 +146,7 @@ module.exports = context => {
     } else {
       throw state.file.buildCodeFrameError(
         node,
-        'The `idx` body can only be composed of properties and methods.',
+        'idx callbacks may only access properties on the callback parameter.',
       );
     }
   }

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -128,26 +128,13 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
-  it('transforms call expressions', () => {
+  it('throws on call expressions', () => {
     expect(`
       const idx = require('idx');
       idx(base, _ => _.b.c(...foo)().d(bar, null, [...baz]));
-    `).toTransformInto(`
-      var _ref;
-      (_ref = base) != null ?
-        (_ref = _ref.b) != null ?
-          (_ref = _ref.c) != null ?
-            (_ref = _ref(...foo)) != null ?
-              (_ref = _ref()) != null ?
-                (_ref = _ref.d) != null ?
-                  _ref(bar, null, [...baz]) :
-                _ref :
-              _ref :
-            _ref :
-          _ref :
-        _ref :
-      _ref;
-    `);
+    `).toThrowTransformError(
+      'idx callbacks may only access properties on the callback parameter.',
+    );
   });
 
   it('transforms bracket notation', () => {
@@ -166,26 +153,13 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
-  it('transforms bracket notation call expressions', () => {
+  it('throws on bracket notation call expressions', () => {
     expect(`
       const idx = require('idx');
       idx(base, _ => _["b"](...foo)()[0][c + d](bar, null, [...baz]));
-    `).toTransformInto(`
-      var _ref;
-      (_ref = base) != null ?
-        (_ref = _ref["b"]) != null ?
-          (_ref = _ref(...foo)) != null ?
-            (_ref = _ref()) != null ?
-              (_ref = _ref[0]) != null ?
-                (_ref = _ref[c + d]) != null ?
-                  _ref(bar, null, [...baz]) :
-                _ref :
-              _ref :
-            _ref :
-          _ref :
-        _ref :
-      _ref;
-    `);
+    `).toThrowTransformError(
+      'idx callbacks may only access properties on the callback parameter.',
+    );
   });
 
   it('transforms combination of both member access notations', () => {
@@ -244,7 +218,7 @@ describe('babel-plugin-idx', () => {
       const idx = require('idx');
       idx(base, _ => (_.a++).b.c);
     `).toThrowTransformError(
-      'The `idx` body can only be composed of properties and methods.',
+      'idx callbacks may only access properties on the callback parameter.',
     );
   });
 
@@ -454,20 +428,13 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
-  it('transforms base call expressions', () => {
+  it('throws on base call expressions', () => {
     expect(`
       const idx = require('idx');
       idx(base, _ => _().b.c);
-    `).toTransformInto(`
-      var _ref;
-      (_ref = base) != null ?
-        (_ref = _ref()) != null ?
-          (_ref = _ref.b) != null ?
-            _ref.c :
-          _ref :
-        _ref :
-      _ref;
-    `);
+    `).toThrowTransformError(
+      'idx callbacks may only access properties on the callback parameter.',
+    );
   });
 
   it('transforms when the idx parent is a scope creating expression', () => {
@@ -779,30 +746,6 @@ describe('babel-plugin-idx', () => {
         const idx = require('idx');
         const base = {a: {b: {c: 2}}};
         idx(base, _ => _.a.b.c);
-      `).toReturn(2);
-    });
-
-    it('works with a method in the start', () => {
-      expect(`
-        const idx = require('idx');
-        const base = {a: {b: {c: () => 2}}};
-        idx(base, _ => _.a.b.c());
-      `).toReturn(2);
-    });
-
-    it('works with a method in the end', () => {
-      expect(`
-        const idx = require('idx');
-        const base = () => ({a: {b: {c: 2}}});
-        idx(base, _ => _().a.b.c);
-      `).toReturn(2);
-    });
-
-    it('works with a method in the middle', () => {
-      expect(`
-        const idx = require('idx');
-        const base = {a: () => ({b: {c: 2}})};
-        idx(base, _ => _.a().b.c);
       `).toReturn(2);
     });
 


### PR DESCRIPTION
Big breaking change! `this` in the callback parameter doesn't work (see #20), but rather than fixing that, since flow doesn't support function calls anyway (see #24), lets just remove the support altogether. If flow adds support for function calls, then I'll re-add this and fix the `this` binding.

Also added a bit to the README emphasizing flow so it's clear that there's a connection between this module and flow.