### PR TITLE
Fix idx calls in async methods

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -175,7 +175,12 @@ module.exports = context => {
       },
     );
     path.replaceWith(replacement);
-    path.scope.push({id: temp});
+    // Hoist to the top if it's an async method.
+    if (path.scope.path.isClassMethod({async: true})) {
+      path.scope.push({id: temp, _blockHoist: 3});
+    } else {
+      path.scope.push({id: temp});
+    }
   }
 
   function isIdxImportOrRequire(node, name) {

--- a/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.test.js
@@ -378,6 +378,34 @@ describe('babel-plugin-idx', () => {
     `);
   });
 
+  it('transforms idx calls in async methods', () => {
+    expect({
+      plugins: [transformAsyncToGenerator, babelPluginIdx],
+      code: `
+        const idx = require('idx');
+        class Foo {
+          async bar() {
+            idx(base, _ => _.b);
+            return this;
+          }
+        }
+      `,
+    }).toTransformInto(`
+      ${asyncToGeneratorHelperCode}
+
+      class Foo {
+        bar() {
+          var _this = this;
+          return _asyncToGenerator(function* () {
+            var _ref;
+            (_ref = base) != null ? _ref.b : _ref;
+            return _this;
+          })();
+        }
+      }
+    `);
+  });
+
   it('transforms idx calls when an idx import binding is in scope', () => {
     expect(`
       import idx from 'idx';


### PR DESCRIPTION
Adding the temp var to the scope of an async method, messes up the `this` reference when using `babel-plugin-transform-async-to-generator`. I don't have better solution than to special handle the scoping in cases where the immediate scope is an async method. Setting `_blockHoist: 3` all of the time doesn't seem to affect the tests, but because this option is poorly documented, I'm not sure on what other consequences that may have. So I'd rather play it safe.

Without this fix, the test would actually transform to:

```js
class Foo {
  bar() {
    return _asyncToGenerator(function* () {
      var _ref,
          _this = this;

      (_ref = base) != null ? _ref.b : _ref;
      return _this;
    })();
  }
}
```

@wbinnssmith hit this issue in Nuclide a while ago, and I just remembered about this.

