### PR TITLE
Add default ES6 export

### DIFF
--- a/packages/idx/src/idx.js
+++ b/packages/idx/src/idx.js
@@ -105,4 +105,5 @@ const getInvalidPropertyAccessErrorPattern: any = new Function('$object$', `
   throw new Error('Expected property access on ' + $object$ + ' to throw.');
 `);
 
+idx.default = idx;
 module.exports = idx;


### PR DESCRIPTION
Required for some build configurations.

For example with this it's possible to use idx with Typescript as is with following typing:

```typescript
declare module "idx" {
    function idx<T, R>(props: T, getPath: (props: T) => R): R;
    export default idx;
}
```

Typescript usage example with strict null checks:

```typescript
import idx from "idx";

interface IState {
    foo?: {
        bar?: {
            baz?: number;
        };
    };
}

const state: IState = {};

var num = idx(state, _ => _.foo!.bar!.baz); 
```