### PR TITLE
Fix regex lint warning

### DIFF
--- a/packages/idx/src/idx.js
+++ b/packages/idx/src/idx.js
@@ -81,8 +81,8 @@ function idx<Ti, Tv>(input: Ti, accessor: (input: Ti) => Tv): ?Tv {
  * TypeError: null is not an object (evaluating 'foo.bar')
  * TypeError: null is not an object (evaluating '(" undefined ", null).bar')
  */
-const nullPattern = /^null | null$|^[^\(]* null /;
-const undefinedPattern = /^undefined | undefined$|^[^\(]* undefined /;
+const nullPattern = /^null | null$|^[^(]* null /;
+const undefinedPattern = /^undefined | undefined$|^[^(]* undefined /;
 
 idx.default = idx;
 module.exports = idx;


### PR DESCRIPTION
Fixes the only lint warnings in the project.

**Test Plan:**
Ran `npm run lint` and `npm run test` successfully.