### PR TITLE
[Issue 46]: Capital case errors shall be matched by *pattern regexes

### DIFF
--- a/packages/idx/src/idx.js
+++ b/packages/idx/src/idx.js
@@ -79,8 +79,8 @@ function idx<Ti, Tv>(input: Ti, accessor: (input: Ti) => Tv): ?Tv {
  * TypeError: null is not an object (evaluating 'foo.bar')
  * TypeError: null is not an object (evaluating '(" undefined ", null).bar')
  */
-const nullPattern = /^null | null$|^[^(]* null /;
-const undefinedPattern = /^undefined | undefined$|^[^(]* undefined /;
+const nullPattern = /^null | null$|^[^(]* null /i;
+const undefinedPattern = /^undefined | undefined$|^[^(]* undefined /i;
 
 idx.default = idx;
 module.exports = idx;

--- a/packages/idx/src/idx.test.js
+++ b/packages/idx/src/idx.test.js
@@ -49,4 +49,26 @@ describe('idx', () => {
     const a = {b: []};
     expect(idx(a, _ => _.b[0].c)).toEqual(undefined);
   });
+  
+  it('returns null for error in capital case', () => {
+    const error = new TypeError('b is NULL');
+    const a = {};
+    Object.defineProperty(a, 'b', {
+      get() {
+        throw error;
+      },
+    });
+    expect(idx(a, _ => _.b.c)).toEqual(null);
+  });
+  
+  it('returns undefined for error in capital case', () => {
+    const error = new TypeError('b is UNDEFINED');
+    const a = {};
+    Object.defineProperty(a, 'b', {
+      get() {
+        throw error;
+      },
+    });
+    expect(idx(a, _ => _.b.c)).toEqual(undefined);
+  });
 });


### PR DESCRIPTION
Made nullPattern, undefinedPattern regexes to be case insensitive. Extended unit tests. Fixes #46 