### PR TITLE
Remove useless export for TS

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -3,5 +3,8 @@
  * @param { Function } accessor - Accessor function
  * @return { T2 }
  */
-export declare function idx<T1, T2>(prop: T1, accessor: (prop: T1) => T2): T2 | null | undefined;
+declare function idx<T1, T2>(
+  prop: T1,
+  accessor: (prop: T1) => T2,
+): T2 | null | undefined;
 export default idx;


### PR DESCRIPTION
`export declare function idx`

means that you can use 

`import { idx } from 'idx'`

in TypeScript but would failed with `TypeError: idx_1.idx is not a function`.