### PR TITLE
Support Typescript non-null assertion operator

### DIFF
--- a/packages/babel-plugin-idx/src/babel-plugin-idx.js
+++ b/packages/babel-plugin-idx/src/babel-plugin-idx.js
@@ -125,8 +125,12 @@ module.exports = context => {
 
   function makeChain(node, state, inside) {
     if (t.isMemberExpression(node)) {
+      let object = node.object;
+      if (node.object.type === 'TSNonNullExpression') {
+        object = node.object.expression;
+      }
       return makeChain(
-        node.object,
+        object,
         state,
         makeCondition(
           t.MemberExpression(state.temp, node.property, node.computed),


### PR DESCRIPTION
This allows use of expressions like this:
```
const v = idx(data, _ => _!.something!.something2)
```
for use within Typescript.