### PR TITLE
Enhance TypeScript types

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -1,7 +1,67 @@
 /**
- * @param { T1 } prop - Parent Object
- * @param { Function } accessor - Accessor function
- * @return { T2 }
+ * NonUndefinedOrnNull
+ * Exclude undefined and null from set `A`
  */
-export declare function idx<T1, T2>(prop: T1, accessor: (prop: T1) => T2): T2 | null | undefined;
+type NonUndefinedOrnNull<T> = T extends (undefined | null) ? never : T;
+
+/**
+ * DeepRequiredArray
+ * Nested array condition handler
+ */
+interface _DeepRequiredArray<T>
+  extends Array<DeepRequired<NonUndefinedOrnNull<T>>> {}
+
+/**
+ * DeepRequiredObject
+ * Nested object condition handler
+ */
+type _DeepRequiredObject<T> = {
+  [P in keyof T]-?: DeepRequired<NonUndefinedOrnNull<T[P]>>
+};
+
+/**
+ * DeepRequired
+ * Required that works for deeply nested structure
+ */
+type DeepRequired<T> = T extends any[]
+  ? _DeepRequiredArray<T[number]>
+  : T extends object ? _DeepRequiredObject<T> : T;
+
+/**
+ * Traverses properties on objects and arrays. If an intermediate property is
+ * either null or undefined, it is instead returned. The purpose of this method
+ * is to simplify extracting properties from a chain of maybe-typed properties.
+ *
+ * Consider the following type:
+ *
+ *     const props: {
+ *       user?: {
+ *         name: string,
+ *         friends?: Array<User>,
+ *       }
+ *     };
+ *
+ * Getting to the friends of my first friend would resemble:
+ *
+ *      props.user &&
+ *      props.user.friends &&
+ *      props.user.friends[0] &&
+ *      props.user.friends[0].friends
+ *
+ * Instead, `idx` allows us to safely write:
+ *
+ *      idx(props, _ => _.user.friends[0].friends)
+ *
+ * The second argument must be a function that returns one or more nested member
+ * expressions. Any other expression has undefined behavior.
+ *
+ * @param prop - Parent Object
+ * @param accessor - Accessor function than c
+ * @return the property accessed if accessor function could reach to property,
+ * null or undefined otherwise
+ */
+declare function idx<T1, T2>(
+  prop: T1,
+  accessor: (prop: DeepRequired<T1>) => T2,
+): T2 | null | undefined;
 export default idx;

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -1,0 +1,38 @@
+import idx from './idx';
+
+interface DeepStructure {
+  foo?: {
+    bar?: {
+      baz?: {
+        arr?: Array<{
+          inner?: {
+            item?: string;
+          };
+        }>;
+      };
+    };
+  };
+}
+
+let deep: DeepStructure = {} as any;
+
+let item: string | undefined | null = idx(
+  deep,
+  _ => _.foo.bar.baz.arr[0].inner.item,
+);
+
+let listOfDeep: DeepStructure[] = [];
+
+item = idx(listOfDeep, _ => _[0].foo.bar.baz.arr[0].inner.item);
+
+interface NullableStructure {
+  foo: {
+    bar: {
+      baz: string | null;
+    } | null;
+  } | null;
+}
+
+let nullable: NullableStructure = {} as any;
+
+let baz: string | null | undefined = idx(nullable, _ => _.foo.bar.baz);


### PR DESCRIPTION
This will allow TypeScript with strictNullCheck flag on to work with
this package. We're making the `prop` argument in the accessor function
a deeply required object so we can safely access it deeply.

I've also added a test file for TypeScript definition so we can make
sure changes to the definition is not breaking them. Currently tests are
not run with any sort of CI. If adding TypeScript as dependency is
desired we can add thtat to test scripts as well