### PR TITLE
Support methods in TypeScript declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "husky": "^0.14.3",
     "lerna": "^2.1.2",
     "prettier": "1.13.5",
-    "pretty-quick": "^1.6.0"
+    "pretty-quick": "^1.6.0",
+    "typescript": "^3.1.6"
   }
 }

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "scripts/build.sh",
     "prepublish": "yarn run build && cp ../../README.md .",
-    "test": "jest"
+    "test": "jest && yarn run tsc",
+    "tsc": "tsc --noEmit --strict"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -8,24 +8,158 @@ type NonUndefinedOrnNull<T> = T extends (undefined | null) ? never : T;
  * DeepRequiredArray
  * Nested array condition handler
  */
-interface _DeepRequiredArray<T>
+interface DeepRequiredArray<T>
   extends Array<DeepRequired<NonUndefinedOrnNull<T>>> {}
 
 /**
  * DeepRequiredObject
  * Nested object condition handler
  */
-type _DeepRequiredObject<T> = {
+type DeepRequiredObject<T> = {
   [P in keyof T]-?: DeepRequired<NonUndefinedOrnNull<T[P]>>
 };
+
+/**
+ * Function that has deeply required return type
+ */
+type FunctionWithRequiredReturnType<
+  T extends (...args: any[]) => any
+> = T extends FunctionWithRequiredReturnType_RestArgs<T>
+  ? FunctionWithRequiredReturnType_RestArgs<T>
+  : T extends FunctionWithRequiredReturnType_Args1<T>
+    ? FunctionWithRequiredReturnType_Args1<T>
+    : T extends FunctionWithRequiredReturnType_Args2<T>
+      ? FunctionWithRequiredReturnType_Args2<T>
+      : T extends FunctionWithRequiredReturnType_Args3<T>
+        ? FunctionWithRequiredReturnType_Args3<T>
+        : T extends FunctionWithRequiredReturnType_Args4<T>
+          ? FunctionWithRequiredReturnType_Args4<T>
+          : T extends FunctionWithRequiredReturnType_Args5<T>
+            ? FunctionWithRequiredReturnType_Args5<T>
+            : T extends FunctionWithRequiredReturnType_Args6<T>
+              ? FunctionWithRequiredReturnType_Args6<T>
+              : T extends FunctionWithRequiredReturnType_Args7<T>
+                ? FunctionWithRequiredReturnType_Args7<T>
+                : T extends FunctionWithRequiredReturnType_NoArgs<T>
+                  ? FunctionWithRequiredReturnType_NoArgs<T>
+                  : FunctionWithRequiredReturnType_AnyArgs<T>;
+
+/**
+ * Function that has deeply required return type with no arguments
+ */
+type FunctionWithRequiredReturnType_AnyArgs<
+  T extends (...args: any[]) => any
+> = T extends (...args: any[]) => infer R
+  ? (...args: any[]) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with rest argument
+ */
+type FunctionWithRequiredReturnType_RestArgs<
+  T extends (...args: any[]) => any
+> = T extends (...args: infer A) => infer R
+  ? (...args: A) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with no arguments
+ */
+type FunctionWithRequiredReturnType_NoArgs<
+  T extends () => any
+> = T extends () => infer R ? () => DeepRequired<R> : never;
+
+/**
+ * Function that has deeply required return type with 1 argument
+ */
+type FunctionWithRequiredReturnType_Args1<
+  T extends (arg: any) => any
+> = T extends (a: infer A) => infer R ? (a: A) => DeepRequired<R> : never;
+
+/**
+ * Function that has deeply required return type with 2 arguments
+ */
+type FunctionWithRequiredReturnType_Args2<
+  T extends (arg: any) => any
+> = T extends (a: infer A, b: infer B) => infer R
+  ? (a: A, b: B) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with 3 arguments
+ */
+type FunctionWithRequiredReturnType_Args3<
+  T extends (arg: any) => any
+> = T extends (a: infer A, b: infer B, c: infer C) => infer R
+  ? (a: A, b: B, c: C) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with 4 arguments
+ */
+type FunctionWithRequiredReturnType_Args4<
+  T extends (arg: any) => any
+> = T extends (a: infer A, b: infer B, c: infer C, d: infer D) => infer R
+  ? (a: A, b: B, c: C, d: D) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with 5 arguments
+ */
+type FunctionWithRequiredReturnType_Args5<
+  T extends (arg: any) => any
+> = T extends (
+  a: infer A,
+  b: infer B,
+  c: infer C,
+  d: infer D,
+  e: infer E,
+) => infer R
+  ? (a: A, b: B, c: C, d: D, e: E) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with 6 arguments
+ */
+type FunctionWithRequiredReturnType_Args6<
+  T extends (arg: any) => any
+> = T extends (
+  a: infer A,
+  b: infer B,
+  c: infer C,
+  d: infer D,
+  e: infer E,
+  f: infer F,
+) => infer R
+  ? (a: A, b: B, c: C, d: D, e: E, f: F) => DeepRequired<R>
+  : never;
+
+/**
+ * Function that has deeply required return type with 7 arguments
+ */
+type FunctionWithRequiredReturnType_Args7<
+  T extends (arg: any) => any
+> = T extends (
+  a: infer A,
+  b: infer B,
+  c: infer C,
+  d: infer D,
+  e: infer E,
+  f: infer F,
+  g: infer G,
+) => infer R
+  ? (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => DeepRequired<R>
+  : never;
 
 /**
  * DeepRequired
  * Required that works for deeply nested structure
  */
 type DeepRequired<T> = T extends any[]
-  ? _DeepRequiredArray<T[number]>
-  : T extends object ? _DeepRequiredObject<T> : T;
+  ? DeepRequiredArray<T[number]>
+  : T extends (...args: any[]) => any
+    ? FunctionWithRequiredReturnType<T>
+    : T extends object ? DeepRequiredObject<T> : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is
@@ -55,8 +189,8 @@ type DeepRequired<T> = T extends any[]
  * The second argument must be a function that returns one or more nested member
  * expressions. Any other expression has undefined behavior.
  *
- * @param prop - Parent Object
- * @param accessor - Accessor function than c
+ * @param prop - Parent object
+ * @param accessor - Accessor function
  * @return the property accessed if accessor function could reach to property,
  * null or undefined otherwise
  */

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -36,3 +36,25 @@ interface NullableStructure {
 let nullable: NullableStructure = {} as any;
 
 let baz: string | null | undefined = idx(nullable, _ => _.foo.bar.baz);
+
+interface WithMethods<T = any> {
+  foo?: {
+    bar?(): number;
+  };
+  baz?: {
+    fn?(): {inner?: string};
+  };
+  args?(a: number): number;
+  manyArgs?(a: number, b: string, c: boolean): number;
+  restArgs?(...args: string[]): string;
+  genrric?(arg: T): T;
+}
+
+let withMethods: WithMethods<boolean> = {} as any;
+
+let n: number | undefined | null = idx(withMethods, _ => _.foo.bar());
+n = idx(withMethods, _ => _.args(1));
+n = idx(withMethods, _ => _.manyArgs(1, 'b', true));
+let s: string | undefined | null = idx(withMethods, _ => _.baz.fn().inner);
+s = idx(withMethods, _ => _.restArgs('1', '2', '3', '4', '5', '6'));
+let b: boolean | undefined | null = idx(withMethods, _ => _.genrric(true));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "strict": true
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
This adds support for methods in the deep structure. It makes sure arguments types are carried over up to 7 arguments. 

Fixes  #60