### PR TITLE
Allow nullables to be passed as a prop in TypeScript

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -1,22 +1,15 @@
 /**
- * NonUndefinedOrnNull
- * Exclude undefined and null from set `A`
- */
-type NonUndefinedOrnNull<T> = T extends (undefined | null) ? never : T;
-
-/**
  * DeepRequiredArray
  * Nested array condition handler
  */
-interface DeepRequiredArray<T>
-  extends Array<DeepRequired<NonUndefinedOrnNull<T>>> {}
+interface DeepRequiredArray<T> extends Array<DeepRequired<NonNullable<T>>> {}
 
 /**
  * DeepRequiredObject
  * Nested object condition handler
  */
 type DeepRequiredObject<T> = {
-  [P in keyof T]-?: DeepRequired<NonUndefinedOrnNull<T[P]>>
+  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
 };
 
 /**
@@ -24,131 +17,8 @@ type DeepRequiredObject<T> = {
  */
 type FunctionWithRequiredReturnType<
   T extends (...args: any[]) => any
-> = T extends FunctionWithRequiredReturnType_RestArgs<T>
-  ? FunctionWithRequiredReturnType_RestArgs<T>
-  : T extends FunctionWithRequiredReturnType_Args1<T>
-    ? FunctionWithRequiredReturnType_Args1<T>
-    : T extends FunctionWithRequiredReturnType_Args2<T>
-      ? FunctionWithRequiredReturnType_Args2<T>
-      : T extends FunctionWithRequiredReturnType_Args3<T>
-        ? FunctionWithRequiredReturnType_Args3<T>
-        : T extends FunctionWithRequiredReturnType_Args4<T>
-          ? FunctionWithRequiredReturnType_Args4<T>
-          : T extends FunctionWithRequiredReturnType_Args5<T>
-            ? FunctionWithRequiredReturnType_Args5<T>
-            : T extends FunctionWithRequiredReturnType_Args6<T>
-              ? FunctionWithRequiredReturnType_Args6<T>
-              : T extends FunctionWithRequiredReturnType_Args7<T>
-                ? FunctionWithRequiredReturnType_Args7<T>
-                : T extends FunctionWithRequiredReturnType_NoArgs<T>
-                  ? FunctionWithRequiredReturnType_NoArgs<T>
-                  : FunctionWithRequiredReturnType_AnyArgs<T>;
-
-/**
- * Function that has deeply required return type with no arguments
- */
-type FunctionWithRequiredReturnType_AnyArgs<
-  T extends (...args: any[]) => any
-> = T extends (...args: any[]) => infer R
-  ? (...args: any[]) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with rest argument
- */
-type FunctionWithRequiredReturnType_RestArgs<
-  T extends (...args: any[]) => any
 > = T extends (...args: infer A) => infer R
   ? (...args: A) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with no arguments
- */
-type FunctionWithRequiredReturnType_NoArgs<
-  T extends () => any
-> = T extends () => infer R ? () => DeepRequired<R> : never;
-
-/**
- * Function that has deeply required return type with 1 argument
- */
-type FunctionWithRequiredReturnType_Args1<
-  T extends (arg: any) => any
-> = T extends (a: infer A) => infer R ? (a: A) => DeepRequired<R> : never;
-
-/**
- * Function that has deeply required return type with 2 arguments
- */
-type FunctionWithRequiredReturnType_Args2<
-  T extends (arg: any) => any
-> = T extends (a: infer A, b: infer B) => infer R
-  ? (a: A, b: B) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with 3 arguments
- */
-type FunctionWithRequiredReturnType_Args3<
-  T extends (arg: any) => any
-> = T extends (a: infer A, b: infer B, c: infer C) => infer R
-  ? (a: A, b: B, c: C) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with 4 arguments
- */
-type FunctionWithRequiredReturnType_Args4<
-  T extends (arg: any) => any
-> = T extends (a: infer A, b: infer B, c: infer C, d: infer D) => infer R
-  ? (a: A, b: B, c: C, d: D) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with 5 arguments
- */
-type FunctionWithRequiredReturnType_Args5<
-  T extends (arg: any) => any
-> = T extends (
-  a: infer A,
-  b: infer B,
-  c: infer C,
-  d: infer D,
-  e: infer E,
-) => infer R
-  ? (a: A, b: B, c: C, d: D, e: E) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with 6 arguments
- */
-type FunctionWithRequiredReturnType_Args6<
-  T extends (arg: any) => any
-> = T extends (
-  a: infer A,
-  b: infer B,
-  c: infer C,
-  d: infer D,
-  e: infer E,
-  f: infer F,
-) => infer R
-  ? (a: A, b: B, c: C, d: D, e: E, f: F) => DeepRequired<R>
-  : never;
-
-/**
- * Function that has deeply required return type with 7 arguments
- */
-type FunctionWithRequiredReturnType_Args7<
-  T extends (arg: any) => any
-> = T extends (
-  a: infer A,
-  b: infer B,
-  c: infer C,
-  d: infer D,
-  e: infer E,
-  f: infer F,
-  g: infer G,
-) => infer R
-  ? (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => DeepRequired<R>
   : never;
 
 /**
@@ -196,6 +66,6 @@ type DeepRequired<T> = T extends any[]
  */
 declare function idx<T1, T2>(
   prop: T1,
-  accessor: (prop: DeepRequired<T1>) => T2,
+  accessor: (prop: NonNullable<DeepRequired<T1>>) => T2,
 ): T2 | null | undefined;
 export default idx;

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -21,6 +21,9 @@ let item: string | undefined | null = idx(
   _ => _.foo.bar.baz.arr[0].inner.item,
 );
 
+let baz = idx(deep, _ => _.foo.bar.baz);
+item = idx(baz, _ => _.arr[0].inner.item);
+
 let listOfDeep: DeepStructure[] = [];
 
 item = idx(listOfDeep, _ => _[0].foo.bar.baz.arr[0].inner.item);
@@ -35,7 +38,7 @@ interface NullableStructure {
 
 let nullable: NullableStructure = {} as any;
 
-let baz: string | null | undefined = idx(nullable, _ => _.foo.bar.baz);
+let bazz: string | null | undefined = idx(nullable, _ => _.foo.bar.baz);
 
 interface WithMethods<T = any> {
   foo?: {
@@ -45,7 +48,19 @@ interface WithMethods<T = any> {
     fn?(): {inner?: string};
   };
   args?(a: number): number;
-  manyArgs?(a: number, b: string, c: boolean): number;
+  manyArgs?(
+    a: number,
+    b: string,
+    c: boolean,
+    d: number,
+    e: number,
+    f: number,
+    g: string,
+    h: string,
+    k: number,
+    l: boolean,
+    m: string,
+  ): number;
   restArgs?(...args: string[]): string;
   genrric?(arg: T): T;
 }
@@ -54,7 +69,9 @@ let withMethods: WithMethods<boolean> = {} as any;
 
 let n: number | undefined | null = idx(withMethods, _ => _.foo.bar());
 n = idx(withMethods, _ => _.args(1));
-n = idx(withMethods, _ => _.manyArgs(1, 'b', true));
+n = idx(withMethods, _ =>
+  _.manyArgs(1, 'b', true, 1, 2, 3, '4', '5', 1, true, ''),
+);
 let s: string | undefined | null = idx(withMethods, _ => _.baz.fn().inner);
 s = idx(withMethods, _ => _.restArgs('1', '2', '3', '4', '5', '6'));
 let b: boolean | undefined | null = idx(withMethods, _ => _.genrric(true));


### PR DESCRIPTION
* accept nullables as object argument so code like this works: 
  ```ts
  let baz = idx(deep, _ => _.foo.bar.baz);
  item = idx(baz, _ => _.arr[0].inner.item);
  ```
* simplify `FunctionWithRequiredReturnType` Thanks to @DanielRosenwasser [suggestion](https://twitter.com/drosenwasser/status/1066217309495283713) 
* use the built in type `NonNullable`

Fixes #64 
Fixes #63 