### PR TITLE
Consistently return `undefined` instead of `null | undefined`

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -2,14 +2,14 @@
  * DeepRequiredArray
  * Nested array condition handler
  */
-interface DeepRequiredArray<T> extends Array<DeepRequired<NonNullable<T>>> {}
+interface DeepRequiredArray<T> extends Array<DeepRequired<T>> {}
 
 /**
  * DeepRequiredObject
  * Nested object condition handler
  */
 type DeepRequiredObject<T> = {
-  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+  [P in keyof T]-?: DeepRequired<T[P]>
 };
 
 /**
@@ -66,6 +66,6 @@ type DeepRequired<T> = T extends any[]
  */
 declare function idx<T1, T2>(
   prop: T1,
-  accessor: (prop: NonNullable<DeepRequired<T1>>) => T2,
-): T2 | null | undefined;
+  accessor: (prop: DeepRequired<T1>) => T2,
+): T2 | undefined;
 export default idx;

--- a/packages/idx/src/idx.js
+++ b/packages/idx/src/idx.js
@@ -61,7 +61,7 @@ function idx<Ti, Tv>(input: Ti, accessor: (input: Ti) => Tv): ?Tv {
   } catch (error) {
     if (error instanceof TypeError) {
       if (nullPattern.test(error)) {
-        return null;
+        return undefined;
       } else if (undefinedPattern.test(error)) {
         return undefined;
       }


### PR DESCRIPTION
_Note: This change I'm about to propose is both controversial and highly breaking, so I don't have any expectations this will be merged as-is, but perhaps it can facilitate some useful discussion._

As outlined in #70 I'd like to narrow the return types of `idx` more. Currently `idx` always returns `T | null | undefined` even when it can be statically inferred that only a subset of those return types are possible to happen. 

In the following example the return type of `getName` should be `string | undefined` but is `string | null | undefined`:
```ts
interface User {
  user?: { name?: string };
}
function getName(user: User) {
 return idx(user, _ => _.user.name);
}
```

**Typescript changes**
To fix the above I changed the type definitions (just for Typescript for now). Below is an example of how the return used to be vs. how they are with my changes.

```ts
interface User {
  user?: {
    name?: string;
    age: number | null;
  };
}

// current return types
function getName(user: User) {
  const name = idx(user, _ => _.user.name); // string | null | undefined
  const age = idx(user, _ => _.user.age); // number | null | undefined
}

// new return types
function getName(user: User) {
  const name = idx(user, _ => _.user.name); // string | undefined
  const age = idx(user, _ => _.user.age); // number | null | undefined
}
```

With my changes `name` no longer has `null` as return type. However `age` still has `null` since this is a possible return value.

**Runtime changes**
While trying to solve the above problem, I had to change the runtime implementation of `idx`. Currently it returns `null` or `undefined` conditionally based on the value of the last accessed parent property:
```js
idx({a: undefined}, _ => _.a.b.c.d) // returns `undefined` at runtime
idx({a: null}, _ => _.a.b.c.d) // returns `null` at runtime:
```

`a` is `undefined` in the first case, and `a` is `null` in the second case. But the property we are attempting to access is `d` which is neither `undefined` or `null`. Consistently returning either `undefined` or `null` in both cases should therefore be fine. And I propose returning `undefined` always.

Closes #70 