### PR TITLE
Add UnboxDeepRequired to fix return type

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -32,6 +32,12 @@ type DeepRequired<T> = T extends any[]
     : T extends object ? DeepRequiredObject<T> : T;
 
 /**
+ * UnboxDeepRequired
+ * Unbox type wraped with DeepRequired
+ */
+type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
+
+/**
  * Traverses properties on objects and arrays. If an intermediate property is
  * either null or undefined, it is instead returned. The purpose of this method
  * is to simplify extracting properties from a chain of maybe-typed properties.
@@ -67,5 +73,5 @@ type DeepRequired<T> = T extends any[]
 declare function idx<T1, T2>(
   prop: T1,
   accessor: (prop: NonNullable<DeepRequired<T1>>) => T2,
-): T2 | null | undefined;
+): UnboxDeepRequired<T2> | null | undefined;
 export default idx;

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -75,3 +75,12 @@ n = idx(withMethods, _ =>
 let s: string | undefined | null = idx(withMethods, _ => _.baz.fn().inner);
 s = idx(withMethods, _ => _.restArgs('1', '2', '3', '4', '5', '6'));
 let b: boolean | undefined | null = idx(withMethods, _ => _.genrric(true));
+
+let foo = idx(withMethods, _ => _.foo);
+// foo should be { bar?(): number }
+let fooTest1: typeof foo = {};
+let fooTest2: typeof foo = {
+  bar(): number {
+    return 1;
+  },
+};


### PR DESCRIPTION
```ts
type Obj = {
  a?: {
    b?: {
      c?: number;
    };
  };
};
const result = idx({} as Obj, _ => _.a.b);
```

In that case `result` should be `{ c?: number }` instead of `DeepRequired<{ c?: number }>` ( as same as `{ c: number }`) .

So I introduce a new type `UnboxDeepRequired` and it works like this: 

`UnboxDeepRequired<DeepRequired<T>>` equals to `T`