### PR TITLE
Fix UnboxDeepRequired type

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -33,9 +33,15 @@ type DeepRequired<T> = T extends any[]
 
 /**
  * UnboxDeepRequired
- * Unbox type wraped with DeepRequired
+ * Unbox type warped with DeepRequired
  */
-type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
+type UnboxDeepRequired<T> = T extends DeepRequired<any>
+  ? T extends DeepRequiredArray<infer R>
+    ? Array<R>
+    : T extends (...args: infer A) => infer R
+      ? (...args: A) => UnboxDeepRequired<R>
+      : T extends DeepRequiredObject<infer R> ? R : T
+  : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is

--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -5,6 +5,12 @@
 interface DeepRequiredArray<T> extends Array<DeepRequired<NonNullable<T>>> {}
 
 /**
+ * Return type of calling `idx()`. `idx` always returns an optional value
+ * @template T Value can be null or undefined
+ */
+export type IDXOptional<T> = T | null | undefined;
+
+/**
  * DeepRequiredObject
  * Nested object condition handler
  */
@@ -33,15 +39,23 @@ type DeepRequired<T> = T extends any[]
 
 /**
  * UnboxDeepRequired
- * Unbox type warped with DeepRequired
+ * Unbox type wrapped with DeepRequired
  */
-type UnboxDeepRequired<T> = T extends DeepRequired<any>
-  ? T extends DeepRequiredArray<infer R>
-    ? Array<R>
-    : T extends (...args: infer A) => infer R
-      ? (...args: A) => UnboxDeepRequired<R>
-      : T extends DeepRequiredObject<infer R> ? R : T
-  : T;
+type UnboxDeepRequired<T> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : T extends symbol
+        ? symbol
+        : T extends bigint
+          ? bigint
+          : T extends DeepRequiredArray<infer R>
+            ? Array<R>
+            : T extends (...args: infer A) => DeepRequired<infer R>
+              ? (...args: A) => UnboxDeepRequired<R>
+              : T extends DeepRequiredObject<infer R> ? R : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is
@@ -79,5 +93,6 @@ type UnboxDeepRequired<T> = T extends DeepRequired<any>
 declare function idx<T1, T2>(
   prop: T1,
   accessor: (prop: NonNullable<DeepRequired<T1>>) => T2,
-): UnboxDeepRequired<T2> | null | undefined;
+): IDXOptional<UnboxDeepRequired<T2>>;
+
 export default idx;

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -1,20 +1,28 @@
 import idx from './idx';
 
+interface Item {
+  inner?: {
+    item?: string;
+  };
+}
+
 interface DeepStructure {
   foo?: {
     bar?: {
       baz?: {
-        arr?: Array<{
-          inner?: {
-            item?: string;
-          };
-        }>;
+        arr?: Item[];
       };
     };
   };
 }
 
 let deep: DeepStructure = {} as any;
+
+let items = idx(deep, _ => _.foo.bar.baz.arr);
+
+let itemOne: Item = items![0];
+
+let innerOfItemOne: {item?: string} | undefined | null = itemOne.inner;
 
 let item: string | undefined | null = idx(
   deep,


### PR DESCRIPTION
When end result is array or a function, return type of function or item type of the array should not be deeply required.

For instance 

```ts
type A = {
  items?: (string | undefined)[]
}

idx({} as A, _ => _.items) // should return type (string | undefined)[] | undefined | null
```