### PR TITLE
Fix types: support enums, make DeepRequiredObject limited to object

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "husky": "^1.3.1",
     "lerna": "^3.11.0",
     "prettier": "1.16.4",
-    "pretty-quick": "^1.10.0",
-    "typescript": "^3.3.3"
+    "pretty-quick": "^1.10.0"
   },
   "husky": {
     "hooks": {

--- a/packages/idx/package.json
+++ b/packages/idx/package.json
@@ -22,7 +22,8 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.1.11",
     "flow-bin": "^0.92.1",
-    "jest": "^19.0.2"
+    "jest": "^19.0.2",
+    "typescript": "^3.3.3333"
   },
   "jest": {
     "testEnvironment": "node",

--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -45,15 +45,7 @@ type UnboxDeepRequired<T> = T extends DeepRequiredArray<infer R>
   ? Array<R>
   : T extends (...args: infer A) => DeepRequired<infer R>
     ? (...args: A) => UnboxDeepRequired<R>
-    : T extends DeepRequiredObject<infer R>
-      ? R
-      : T extends string
-        ? string
-        : T extends number
-          ? number
-          : T extends boolean
-            ? boolean
-            : T extends symbol ? symbol : T extends bigint ? bigint : T;
+    : T extends DeepRequiredObject<infer R> ? R : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is

--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -14,9 +14,9 @@ export type IDXOptional<T> = T | null | undefined;
  * DeepRequiredObject
  * Nested object condition handler
  */
-type DeepRequiredObject<T> = {
-  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
-};
+type DeepRequiredObject<T> = T extends object
+  ? {[P in keyof T]-?: DeepRequired<NonNullable<T[P]>>}
+  : T;
 
 /**
  * Function that has deeply required return type
@@ -41,21 +41,19 @@ type DeepRequired<T> = T extends any[]
  * UnboxDeepRequired
  * Unbox type wrapped with DeepRequired
  */
-type UnboxDeepRequired<T> = T extends string
-  ? string
-  : T extends number
-    ? number
-    : T extends boolean
-      ? boolean
-      : T extends symbol
-        ? symbol
-        : T extends bigint
-          ? bigint
-          : T extends DeepRequiredArray<infer R>
-            ? Array<R>
-            : T extends (...args: infer A) => DeepRequired<infer R>
-              ? (...args: A) => UnboxDeepRequired<R>
-              : T extends DeepRequiredObject<infer R> ? R : T;
+type UnboxDeepRequired<T> = T extends DeepRequiredArray<infer R>
+  ? Array<R>
+  : T extends (...args: infer A) => DeepRequired<infer R>
+    ? (...args: A) => UnboxDeepRequired<R>
+    : T extends DeepRequiredObject<infer R>
+      ? R
+      : T extends string
+        ? string
+        : T extends number
+          ? number
+          : T extends boolean
+            ? boolean
+            : T extends symbol ? symbol : T extends bigint ? bigint : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -74,3 +74,16 @@ it('maintains the return type of method calls', () => {
     req.inner.toFixed(); // can safely call because inner is not optional
   }
 });
+
+it('can unbox enums', () => {
+  enum Enum {
+    ONE = 'ONE',
+  }
+  type WithEnum = {
+    foo?: {
+      enum?: Enum;
+    };
+  };
+
+  let e: IDXOptional<Enum> = idx({} as WithEnum, _ => _.foo.enum);
+});


### PR DESCRIPTION
Fixes #78 

* Make `DeepRequiredObject` strictly limited to `object` types so it doesn't unwrap primitive types 
* Update `UnboxDeepRequired` to check for objects and arrays before checking for primitives 
* Move TypeScript dependency down to idx package