### PR TITLE
Fix several recent types bugs

### DIFF
--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -74,3 +74,16 @@ it('maintains the return type of method calls', () => {
     req.inner.toFixed(); // can safely call because inner is not optional
   }
 });
+
+it('can unbox enums', () => {
+  enum Enum {
+    ONE = 'ONE',
+  }
+  type WithEnum = {
+    foo?: {
+      enum?: Enum;
+    };
+  };
+
+  let e: IDXOptional<Enum> = idx({} as WithEnum, _ => _.foo.enum);
+});

--- a/packages/idx/tsconfig.json
+++ b/packages/idx/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
# Support enum type

The key of issue is here
https://github.com/facebookincubator/idx/blob/361d07e4979cf7b2b53ad79481411dc1b11dc96a/packages/idx/src/idx.d.ts#L44-L45

We should not use `extends string` otherwise the `enum` will become `string / number`. For example:

```ts
enum MyEnum {
  ONE = 'ONE',
}
type Wrap<T> = T extends string ? string : never;
type Result = Wrap<MyEnum>; // Result is string
```

Close issue: https://github.com/facebookincubator/idx/issues/78
Close PR: https://github.com/facebookincubator/idx/pull/80

# Cannot find name `bigint`

Same reason as previous issue. 

Close issue: https://github.com/facebookincubator/idx/issues/77
Close PR: https://github.com/facebookincubator/idx/pull/79

# Deeply required array / function

It works if you check each of `extends Deep*` types in `UnboxDeepRequired`.

Remember not to check `extends string` otherwise the previous issues will happen.

```ts
type UnboxDeepRequired<T> = T extends DeepRequired<infer R>
  ? R
  : T extends FunctionWithRequiredReturnType<infer A, infer R>
  ? (...args: A) => R
  : T extends DeepRequiredArray<infer R>
  ? Array<R>
  : T extends DeepRequiredObject<infer R>
  ? R
  : T;
```

Refactor PR: https://github.com/facebookincubator/idx/pull/76

# B.T.W.

I add a `tsconfig.json` file for better development experiments in VSCode.

> This line works in non-strict mode and it's really confusing :(
> `let a: MyEnum = null`

# CC

@Jimexist
@mohsen1 
@brieb 
@yungsters 

Great thanks for your patience to review the PR. I'm trying to end the mess stage. @yungsters 