### PR TITLE
Refactor DeepRequiredObject and support primitive

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -14,9 +14,9 @@ export type IDXOptional<T> = T | null | undefined;
  * DeepRequiredObject
  * Nested object condition handler
  */
-type DeepRequiredObject<T> = T extends object
-  ? {[P in keyof T]-?: DeepRequired<NonNullable<T[P]>>}
-  : T;
+type DeepRequiredObject<T extends object> = {
+  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+};
 
 /**
  * Function that has deeply required return type
@@ -34,18 +34,16 @@ type FunctionWithRequiredReturnType<
 type DeepRequired<T> = T extends any[]
   ? DeepRequiredArray<T[number]>
   : T extends (...args: any[]) => any
-    ? FunctionWithRequiredReturnType<T>
-    : T extends object ? DeepRequiredObject<T> : T;
+  ? FunctionWithRequiredReturnType<T>
+  : T extends object
+  ? DeepRequiredObject<T>
+  : T;
 
 /**
  * UnboxDeepRequired
  * Unbox type wrapped with DeepRequired
  */
-type UnboxDeepRequired<T> = T extends DeepRequiredArray<infer R>
-  ? Array<R>
-  : T extends (...args: infer A) => DeepRequired<infer R>
-    ? (...args: A) => UnboxDeepRequired<R>
-    : T extends DeepRequiredObject<infer R> ? R : T;
+type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is


### PR DESCRIPTION
# Background

In https://github.com/facebookincubator/idx/pull/80 `DeepRequiredObject` is limited to `object`. 

I think it is better to use `extends` in type param instead of type  expression.

# What

Before:

```ts
type DeepRequiredObject<T> = T  extends object ? {
  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
} : T;
```

After:

```ts
type DeepRequiredObject<T extends object> = {
  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
};
```

---

I also refactor the `UnboxDeepRequired` otherwise unit test will fail:

```ts
type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
```

We don't have to handle each case manually like

![image](https://user-images.githubusercontent.com/1812118/54333950-54cbf180-465f-11e9-8488-a1135d478599.png)

---

For details, these conditions may cause primitive type issue. For example is you pass `string` to `UnboxDeepRequired`:

```ts
type RequiredString = DeepRequired<string>;
type T1 = RequiredString extends DeepRequired<infer R> ? R: never;
type T2 = RequiredString extends DeepRequiredObject<infer R> ? R: never;
```

`RequiredString` is still `string`. 
`T1` is `string`.
`T2` is `string`'s prototype:
![image](https://user-images.githubusercontent.com/1812118/54333701-77a9d600-465e-11e9-8717-92c50ac73c54.png)

The conditions also cause the enum support issue.

# Why

This PR doesn't change any API and passed all existing test cases without adding new test.
This PR also fix the support of function return type and unit test cases [here](https://github.com/facebookincubator/idx/pull/85).
Thanks for your patience to review it.

# CC

@Jimexist
@mohsen1
@brieb
@yungsters 