### PR TITLE
Add test case for function return type

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -14,9 +14,9 @@ export type IDXOptional<T> = T | null | undefined;
  * DeepRequiredObject
  * Nested object condition handler
  */
-type DeepRequiredObject<T> = T extends object
-  ? {[P in keyof T]-?: DeepRequired<NonNullable<T[P]>>}
-  : T;
+type DeepRequiredObject<T extends object> = {
+  [P in keyof T]-?: DeepRequired<NonNullable<T[P]>>
+};
 
 /**
  * Function that has deeply required return type
@@ -34,18 +34,16 @@ type FunctionWithRequiredReturnType<
 type DeepRequired<T> = T extends any[]
   ? DeepRequiredArray<T[number]>
   : T extends (...args: any[]) => any
-    ? FunctionWithRequiredReturnType<T>
-    : T extends object ? DeepRequiredObject<T> : T;
+  ? FunctionWithRequiredReturnType<T>
+  : T extends object
+  ? DeepRequiredObject<T>
+  : T;
 
 /**
  * UnboxDeepRequired
  * Unbox type wrapped with DeepRequired
  */
-type UnboxDeepRequired<T> = T extends DeepRequiredArray<infer R>
-  ? Array<R>
-  : T extends (...args: infer A) => DeepRequired<infer R>
-    ? (...args: A) => UnboxDeepRequired<R>
-    : T extends DeepRequiredObject<infer R> ? R : T;
+type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
 
 /**
  * Traverses properties on objects and arrays. If an intermediate property is

--- a/packages/idx/src/idx.test.ts
+++ b/packages/idx/src/idx.test.ts
@@ -13,6 +13,10 @@ interface Item<T = any> {
   };
 }
 
+interface MethodReturnType<T = any> {
+  optional?: {member?: Item<T>};
+}
+
 interface DeepStructure<T = any> {
   str?: string;
   undef?: undefined;
@@ -29,7 +33,7 @@ interface DeepStructure<T = any> {
   requiredInner?: {
     inner: boolean;
   };
-  method?(): {optional?: {member?: Item<T>}};
+  method?(): MethodReturnType<T>;
   args?(a: string, b: number, c?: boolean): Item<T>;
   requiredReturnType?(): {inner: number};
 }
@@ -86,4 +90,10 @@ it('can unbox enums', () => {
   };
 
   let e: IDXOptional<Enum> = idx({} as WithEnum, _ => _.foo.enum);
+});
+
+it('can unbox function', () => {
+  const returnValue = idx(deep, _ => _.method());
+  const control: MethodReturnType = {optional: {}};
+  const treatment: typeof returnValue = {optional: {}};
 });


### PR DESCRIPTION
# Why

This PR is based on https://github.com/facebookincubator/idx/pull/84 . So please review / merge that PR before this.

Since `UnboxDeepRequired` is refactored to

```ts
type UnboxDeepRequired<T> = T extends DeepRequired<infer R> ? R : T;
```

It also support function return type. So I add a unit test case here.

# CC

@Jimexist
@mohsen1
@brieb
@yungsters