### PR TITLE
WIP: Allow for undefined function return values.

### DIFF
--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -37,9 +37,7 @@ type DeepRequired<T> = T extends any[]
   ? FunctionWithRequiredReturnType<T>
   : T extends object
   ? DeepRequiredObject<T>
-  : T extends undefined | null
-  ? never
-  : T;
+  : NonNullable<T>;
 
 /**
  * UnboxDeepRequired

--- a/packages/idx/src/idx.d.ts
+++ b/packages/idx/src/idx.d.ts
@@ -37,6 +37,8 @@ type DeepRequired<T> = T extends any[]
   ? FunctionWithRequiredReturnType<T>
   : T extends object
   ? DeepRequiredObject<T>
+  : T extends undefined | null
+  ? never
   : T;
 
 /**


### PR DESCRIPTION
(First of all, sorry the commit message is horrible...GitHub UI was a bit confusing there)

At the moment the types don't cover
```ts
interface B{
 b: string
}

interface A{
    getter() : B | undefined
}

const a = new A();
idx(A, _ => _.getter().B)
```

A workaround would be 
```ts
idx(A, _ => _.getter()!.B)
```
except this causes problems when used with https://github.com/dralletje/idx.macro because the `typescript` syntax makes it into the babel macro before it's transformed and thus you get a `buildCodeFrameError` with the message

> The `idx` body can only be composed of properties and methods.

I'm not a typing pro yet so especially for these recursive selectors I'm not sure if this would fix it but at least it's a "fixes-the-red-squiggly-lines" for me :-) Happy for input.